### PR TITLE
Added check for Jira Cloud URL & changed auth header to Basic

### DIFF
--- a/workflow_templater/urlopen_jira.py
+++ b/workflow_templater/urlopen_jira.py
@@ -95,7 +95,10 @@ def urlopen_jira(url, method='GET', data=None, user=None, keyring_service=None, 
                 'Content-Type': 'application/json',
             }
             if access_token is not None:
-                headers["Authorization"] = f"Bearer {access_token}"
+                if jira_base.endswith('atlassian.net'):
+                    headers["Authorization"] = f"Basic {access_token}"
+                else:
+                    headers["Authorization"] = f"Bearer {access_token}"
             elif user is not None:
                 headers['Cookie'] = get_cookie(keyring_service, user, jira_base=jira_base, overwrite=bad_cookies)
 


### PR DESCRIPTION
Attempting to use this for Jira Cloud I noticed that the Bearer token header wasn't working & looking further it looks like only using the Basic header of the user/api token in base64 would do what was needed

https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/

I'm unable to test this against a non Cloud install with the Bearer token, but the changes I've made here should fall through. Not sure if there is a better way to check for Jira cloud than the domain suffix, but it works & was quick :)